### PR TITLE
Do not push 'bill' into the related_bills list

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -277,9 +277,6 @@ BILL_SERIALIZE = dict([
 ])
 
 
-BILL_SERIALIZE['related_bills']['bill'] = BILL_SERIALIZE
-
-
 VOTE_SERIALIZE = dict([
     ("id", {}),
     ("identifier", {}),


### PR DESCRIPTION
This PR removes the full `bill` object from the related_bills list on the OCD API.